### PR TITLE
fix: correct token bucket refill rate for COUNT requests per PER period

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,31 +11,26 @@ use tokio::net::TcpListener;
 /// Main entry point for an Axum application that demonstrates various rate limiting strategies.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Set up the TCP listener on port 8080 of all available network interfaces.
     let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 8080))).await?;
 
-    // Build the router with specific routes and their associated rate limits.
     let app = Router::new()
-        // Route to limit requests based on the HTTP method. The rate limit allows 2 requests per 500 milliseconds.
         .route(
             "/limit-2-per-500-ms-by-method",
             get(limit_2_per_500_ms_by_method),
         )
-        .with_state(LimitState::<Method>::default()) // Initialize state for rate limiting based on HTTP method.
-        // Route to limit requests based on the request URI. The rate limit allows 4 requests per second.
+        .with_state(LimitState::<Method>::default())
         .route("/limit-4-per-sec-by-uri", get(limit_4_per_sec_by_uri))
-        .with_state(LimitState::<Uri>::default()) // Initialize state for rate limiting based on URI.
-        // Route to limit requests based on a custom ID extracted from the request. The rate limit allows 100 requests per hour.
+        .with_state(LimitState::<Uri>::default())
         .route(
-            "/limit-100-per-hour-by-uri-id",
+            "/limit-100-per-hour-by-uri-id/:id/:name",
             get(limit_100_per_hour_by_id),
         )
-        // Another route using the same ID-based rate limiting logic, but allowing 10,000 requests per day.
         .route(
-            "/limit-10000-per-day-by-uri-id",
+            "/limit-10000-per-day-by-uri-id/:id/:name",
             get(limit_10000_per_day_by_id),
         )
-        .with_state(LimitState::<(Uri, Id)>::default()); // Initialize state for rate limiting based on custom ID, shared by two routes.
+        .with_state(LimitState::<(Uri, Id)>::default());
+
     axum::serve(listener, app).await?;
     Ok(())
 }
@@ -47,7 +42,11 @@ async fn limit_100_per_hour_by_id(
 ) {
     println!("{uri}, {name}");
 }
-async fn limit_10000_per_day_by_id(_: LimitPerDay<10000, (Uri, Id)>) {}
+async fn limit_10000_per_day_by_id(
+    Limit((_uri, Path(Data { id, .. }))): LimitPerDay<10000, (Uri, Id)>,
+) {
+    println!("id: {id:?}");
+}
 
 #[derive(Debug, Deserialize)]
 struct Data {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,17 +117,26 @@ pub trait Key: Eq + Hash + Send + Sync {
 /// This struct manages the tokens for rate limiting, providing methods to acquire and refill tokens based on time elapsed.
 struct TokenBucket {
     tokens: usize,
+    max_tokens: usize,
     last_refill_time: Instant,
-    refill_duration: Duration,
+    /// Nanoseconds required to generate one token.
+    ns_per_token: u64,
 }
 
 impl TokenBucket {
     /// Constructs a new `TokenBucket` with a specific number of tokens and a refill period.
-    fn new(tokens: impl Into<usize>, per: impl Into<u64>) -> Self {
+    ///
+    /// `count` is the bucket capacity and burst size. `per` is the period in milliseconds
+    /// over which `count` tokens are replenished.
+    fn new(count: usize, per: u64) -> Self {
+        let max_tokens = count.max(1);
+        let ns_per_token = (per.saturating_mul(1_000_000) / max_tokens as u64).max(1);
+
         Self {
-            tokens: tokens.into(),
+            tokens: max_tokens,
+            max_tokens,
             last_refill_time: Instant::now(),
-            refill_duration: Duration::from_millis(per.into()),
+            ns_per_token,
         }
     }
 
@@ -146,19 +155,13 @@ impl TokenBucket {
     fn refill(&mut self) {
         let now = Instant::now();
         let elapsed = now.duration_since(self.last_refill_time);
+        let elapsed_ns = elapsed.as_nanos() as u64;
 
-        // Calculate the elapsed time in milliseconds
-        if elapsed >= self.refill_duration {
-            let elapsed_millis = elapsed.as_millis() as u64; // Convert elapsed time to milliseconds
-            let refill_duration_millis = self.refill_duration.as_millis() as u64; // Convert refill duration to milliseconds
-
-            // Calculate the number of new tokens to add
-            let new_tokens = (elapsed_millis / refill_duration_millis) as usize;
-            self.tokens += new_tokens;
-
-            // Reset the last refill time to avoid under-refilling tokens
-            self.last_refill_time =
-                now - Duration::from_millis(elapsed_millis % refill_duration_millis);
+        if elapsed_ns >= self.ns_per_token {
+            let new_tokens = (elapsed_ns / self.ns_per_token) as usize;
+            self.tokens = (self.tokens + new_tokens).min(self.max_tokens);
+            let remainder_ns = elapsed_ns % self.ns_per_token;
+            self.last_refill_time = now - Duration::from_nanos(remainder_ns);
         }
     }
 }
@@ -340,5 +343,34 @@ mod tests {
         // 再次请求应该成功
         let response = server.get(TEST_ROUTE).await;
         assert_eq!(response.status_code(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn limit_per_second_allows_count_per_second() {
+        const ROUTE: &str = "/per_sec";
+        async fn handler(_: LimitPerSecond<5, Uri>) -> impl IntoResponse {}
+
+        let app = Router::new()
+            .route(ROUTE, get(handler))
+            .with_state(LimitState::default());
+
+        let server = TestServer::new(app).expect("server");
+
+        for _ in 0..5 {
+            assert_eq!(server.get(ROUTE).await.status_code(), StatusCode::OK);
+        }
+        assert_eq!(
+            server.get(ROUTE).await.status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        for _ in 0..5 {
+            assert_eq!(server.get(ROUTE).await.status_code(), StatusCode::OK);
+        }
+        assert_eq!(
+            server.get(ROUTE).await.status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The token bucket rate limiter did not match its documented semantics. `LimitPerSecond<5>` allowed an initial burst of 5 requests, but only refilled **1 token per second** afterward instead of sustaining **5 requests per second**.

This PR fixes the refill logic and repairs the example routes that were missing required path parameters.

## Problem

`TokenBucket` treated `PER` as the interval for refilling a single token:

- `Limit<COUNT, PER, K>` started with `COUNT` tokens
- After the burst was consumed, only `elapsed / PER` tokens were added
- Result: sustained throughput was **1 request per PER**, not **COUNT requests per PER**

For example, `LimitPerSecond<5, Uri>` behaved like "burst 5, then 1 req/s" instead of "5 req/s".

## Fix

- Distribute `COUNT` token replenishment evenly across `PER` milliseconds (`ns_per_token = PER * 1_000_000 / COUNT`)
- Cap the bucket at `COUNT` to prevent unbounded token accumulation
- Add a regression test for `LimitPerSecond<5, Uri>`
- Fix `examples/basic.rs` routes to include `/:id/:name` path segments required by `Path<Data>`

## Test plan

- [x] `cargo test` (3 unit tests + doc test)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo build --example basic`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f162e-467c-7095-a61d-46e6824edb41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f162e-467c-7095-a61d-46e6824edb41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

