### PR TITLE
feat: 动态额度支持（QuotaSource + DynamicLimit）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "axum-limit"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "axum-limit"
-version = "0.2.0-alpha.4"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-limit"
-version = "0.2.0-alpha.4"
+version = "0.1.0"
 description = "Production-oriented rate limiting for Axum via extractors, with pluggable algorithms and storage backends."
 authors = ["GengTeng <me@gteng.org>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-limit"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Production-oriented rate limiting for Axum via extractors, with pluggable algorithms and storage backends."
 authors = ["GengTeng <me@gteng.org>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Production-oriented rate limiting for Axum with pluggable algorithms and storage
 
 - **Algorithms**: token bucket, fixed window, sliding window counter
 - **Backends**: in-memory (single node), Redis (multi-node, `redis` feature), custom via [`RateLimitBackend`]
-- **Extractor API**: declare limits in handler signatures
+- **Extractor API**: declare limits in handler signatures (static or config-backed)
 - **Standard headers**: `X-RateLimit-*` and `Retry-After`
 - **Verified behavior**: deterministic tests + `proptest`
 
@@ -34,6 +34,69 @@ async fn main() {
     // axum::serve(..., app).await
 }
 ```
+
+## Dynamic quota (from config)
+
+Keep the algorithm fixed in the handler type and load [`Quota`] from application state:
+
+```rust,no_run
+use axum_core::extract::FromRef;
+use axum_limit::{DynamicLimit, LimitState, Quota};
+use http::Uri;
+
+#[derive(Clone)]
+struct AppState {
+    limits: LimitState<Uri>,
+    api_quota: Quota, // loaded from config at startup
+}
+
+impl FromRef<AppState> for LimitState<Uri> {
+    fn from_ref(state: &AppState) -> Self {
+        state.limits.clone()
+    }
+}
+
+impl FromRef<AppState> for Quota {
+    fn from_ref(state: &AppState) -> Quota {
+        state.api_quota
+    }
+}
+
+async fn handler(_: DynamicLimit<Uri, Quota>) -> impl axum::response::IntoResponse {}
+
+#[tokio::main]
+async fn main() {
+    let state = AppState {
+        limits: LimitState::default(),
+        api_quota: Quota::per_second(100),
+    };
+
+    let _app: axum::Router<AppState> = axum::Router::new()
+        .route("/api", axum::routing::get(handler))
+        .with_state(state);
+}
+```
+
+For multiple quotas in one `AppState`, use a marker newtype with [`FromRef`]:
+
+```rust,no_run
+use axum_core::extract::FromRef;
+use axum_limit::{DynamicLimit, Quota};
+
+#[derive(Clone, Copy)]
+struct ApiQuota(Quota);
+
+impl From<ApiQuota> for Quota {
+    fn from(value: ApiQuota) -> Self {
+        value.0
+    }
+}
+// impl FromRef<AppState> for ApiQuota { ... }
+
+async fn handler(_: DynamicLimit<http::Uri, ApiQuota>) {}
+```
+
+Changing a quota at runtime uses a new storage fingerprint, so existing counters are not carried over.
 
 ## Redis backend (multi-node)
 
@@ -116,8 +179,8 @@ Custom keys must implement [`StorageKey`] in addition to [`Key`].
 
 | Algorithm | Extractor | Best for |
 |-----------|-----------|----------|
-| Token bucket | `Limit`, `LimitPerSecond` | Bursts with smooth sustained rate |
-| Fixed window | `FixedWindowLimit` | Lowest overhead |
-| Sliding window | `SlidingWindowLimit` | Fair limits without window spikes |
+| Token bucket | `Limit`, `LimitPerSecond`, `DynamicLimit` | Bursts with smooth sustained rate |
+| Fixed window | `FixedWindowLimit`, `DynamicFixedWindowLimit` | Lowest overhead |
+| Sliding window | `SlidingWindowLimit`, `DynamicSlidingWindowLimit` | Fair limits without window spikes |
 
 See the `examples/` directory for more.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -122,3 +122,25 @@ where
     let snapshot = state.try_acquire(now_ms);
     Ok((state.encode()?, snapshot))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::{FixedWindowPolicy, TokenBucketPolicy};
+    use crate::quota::Quota;
+
+    #[test]
+    fn build_storage_key_includes_policy_quota_and_subject() {
+        let quota = Quota::with_burst(5, 1000, 10);
+        let key = build_storage_key::<TokenBucketPolicy>("ns", "user-1", quota);
+        assert_eq!(key, "ns:token_bucket:5:1000:10:user-1");
+    }
+
+    #[test]
+    fn different_quotas_produce_different_storage_keys() {
+        let subject = "shared";
+        let key_a = build_storage_key::<FixedWindowPolicy>("ns", subject, Quota::new(1, 1000));
+        let key_b = build_storage_key::<FixedWindowPolicy>("ns", subject, Quota::new(5, 1000));
+        assert_ne!(key_a, key_b);
+    }
+}

--- a/src/backend/redis.rs
+++ b/src/backend/redis.rs
@@ -111,3 +111,44 @@ impl RateLimitBackend for RedisBackend {
         Err(BackendError::Contention)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::TokenBucketPolicy;
+    use crate::quota::Quota;
+
+    #[tokio::test]
+    #[ignore = "requires a running Redis server at redis://127.0.0.1/"]
+    async fn transact_persists_state() {
+        let backend = RedisBackend::connect("redis://127.0.0.1/")
+            .await
+            .expect("redis connection");
+        let storage_key = format!(
+            "test:{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        );
+        let quota = Quota::per_second(2);
+
+        let first = backend
+            .transact::<TokenBucketPolicy>(&storage_key, quota, 1_000_000)
+            .await
+            .expect("first transact");
+        assert!(first.allowed);
+
+        let second = backend
+            .transact::<TokenBucketPolicy>(&storage_key, quota, 1_000_000)
+            .await
+            .expect("second transact");
+        assert!(second.allowed);
+
+        let third = backend
+            .transact::<TokenBucketPolicy>(&storage_key, quota, 1_000_000)
+            .await
+            .expect("third transact");
+        assert!(!third.allowed);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,4 +776,166 @@ mod tests {
             StatusCode::TOO_MANY_REQUESTS
         );
     }
+
+    #[tokio::test]
+    async fn different_keys_are_isolated() {
+        let state = LimitState::<Uri>::default();
+        let route_a: Uri = "/a".parse().expect("valid uri");
+        let route_b: Uri = "/b".parse().expect("valid uri");
+        let quota = Quota::per_second(1);
+
+        assert!(
+            state
+                .check(route_a.clone(), quota)
+                .await
+                .expect("a")
+                .allowed
+        );
+        assert!(!state.check(route_a, quota).await.expect("a").allowed);
+        assert!(state.check(route_b, quota).await.expect("b").allowed);
+    }
+
+    #[test]
+    fn rate_limit_headers_from_parts_reads_extension() {
+        let mut parts = http::Request::new(()).into_parts().0;
+        parts.extensions.insert(RateLimitInfo(RateLimitSnapshot {
+            allowed: true,
+            limit: 5,
+            remaining: 4,
+            reset_at_ms: 1_000,
+        }));
+
+        let headers = rate_limit_headers_from_parts(&parts).expect("headers");
+        assert_eq!(
+            headers
+                .get("x-ratelimit-limit")
+                .and_then(|value| value.to_str().ok()),
+            Some("5")
+        );
+        assert_eq!(
+            headers
+                .get("x-ratelimit-remaining")
+                .and_then(|value| value.to_str().ok()),
+            Some("4")
+        );
+    }
+
+    #[tokio::test]
+    async fn dynamic_fixed_window_limit_reads_quota_from_state() {
+        #[derive(Clone)]
+        struct FixedConfigState {
+            limits: LimitState<Uri, FixedWindowPolicy>,
+            api_quota: Quota,
+        }
+
+        impl FromRef<FixedConfigState> for LimitState<Uri, FixedWindowPolicy> {
+            fn from_ref(state: &FixedConfigState) -> Self {
+                state.limits.clone()
+            }
+        }
+
+        impl FromRef<FixedConfigState> for Quota {
+            fn from_ref(state: &FixedConfigState) -> Quota {
+                state.api_quota
+            }
+        }
+
+        const ROUTE: &str = "/dynamic_fixed";
+        async fn handler(_: DynamicFixedWindowLimit<Uri, Quota>) -> impl IntoResponse {}
+
+        let state = FixedConfigState {
+            limits: LimitState::<Uri, FixedWindowPolicy>::default(),
+            api_quota: Quota::per_second(2),
+        };
+
+        let app = Router::new().route(ROUTE, get(handler)).with_state(state);
+        let server = TestServer::new(app);
+
+        assert_eq!(server.get(ROUTE).await.status_code(), StatusCode::OK);
+        assert_eq!(server.get(ROUTE).await.status_code(), StatusCode::OK);
+        assert_eq!(
+            server.get(ROUTE).await.status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+
+    #[tokio::test]
+    async fn dynamic_sliding_window_limit_reads_quota_from_state() {
+        #[derive(Clone)]
+        struct SlidingConfigState {
+            limits: LimitState<Uri, SlidingWindowPolicy>,
+            api_quota: Quota,
+        }
+
+        impl FromRef<SlidingConfigState> for LimitState<Uri, SlidingWindowPolicy> {
+            fn from_ref(state: &SlidingConfigState) -> Self {
+                state.limits.clone()
+            }
+        }
+
+        impl FromRef<SlidingConfigState> for Quota {
+            fn from_ref(state: &SlidingConfigState) -> Quota {
+                state.api_quota
+            }
+        }
+
+        const ROUTE: &str = "/dynamic_sliding";
+        async fn handler(_: DynamicSlidingWindowLimit<Uri, Quota>) -> impl IntoResponse {}
+
+        let state = SlidingConfigState {
+            limits: LimitState::<Uri, SlidingWindowPolicy>::default(),
+            api_quota: Quota::per_second(1),
+        };
+
+        let app = Router::new().route(ROUTE, get(handler)).with_state(state);
+        let server = TestServer::new(app);
+
+        assert_eq!(server.get(ROUTE).await.status_code(), StatusCode::OK);
+        assert_eq!(
+            server.get(ROUTE).await.status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+
+    #[derive(Clone)]
+    struct FailingBackend;
+
+    #[async_trait::async_trait]
+    impl RateLimitBackend for FailingBackend {
+        type Error = BackendError;
+
+        fn namespace(&self) -> &str {
+            "failing"
+        }
+
+        async fn transact<P>(
+            &self,
+            _storage_key: &str,
+            _quota: Quota,
+            _now_ms: u64,
+        ) -> Result<RateLimitSnapshot, Self::Error>
+        where
+            P: RateLimitPolicy,
+        {
+            Err(BackendError::Contention)
+        }
+    }
+
+    #[tokio::test]
+    async fn backend_failure_returns_service_unavailable() {
+        const ROUTE: &str = "/backend_fail";
+        async fn handler(_: Limit<1, 1000, Uri, FailingBackend>) -> impl IntoResponse {}
+
+        let app = Router::new()
+            .route(ROUTE, get(handler))
+            .with_state(LimitState::<Uri, TokenBucketPolicy, FailingBackend>::new(
+                FailingBackend,
+            ));
+
+        let server = TestServer::new(app);
+        assert_eq!(
+            server.get(ROUTE).await.status_code(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod codec;
 mod key;
 mod policy;
 mod quota;
+mod quota_source;
 mod snapshot;
 mod time;
 
@@ -13,6 +14,7 @@ use axum_core::extract::{FromRef, FromRequestParts};
 use axum_core::response::{IntoResponse, Response};
 use http::request::Parts;
 use http::StatusCode;
+use std::convert::Infallible;
 use std::error::Error;
 use std::fmt::Display;
 use std::marker::PhantomData;
@@ -29,6 +31,7 @@ pub use policy::{
     FixedWindowPolicy, PolicyState, RateLimitPolicy, SlidingWindowPolicy, TokenBucketPolicy,
 };
 pub use quota::{Quota, QuotaFingerprint};
+pub use quota_source::{FixedQuota, QuotaSource};
 pub use snapshot::{RateLimitInfo, RateLimitSnapshot};
 
 macro_rules! define_limit_extractor {
@@ -183,6 +186,171 @@ define_limit_extractor! {
     SlidingWindowLimit => SlidingWindowPolicy
 }
 
+macro_rules! define_dynamic_limit_extractor {
+    (
+        $(#[$struct_meta:meta])*
+        $name:ident => $policy:ty
+    ) => {
+        $(#[$struct_meta])*
+        #[derive(Debug, Clone)]
+        pub struct $name<K, Q, B = MemoryBackend>(
+            pub K::Extractor,
+            pub Quota,
+            pub std::marker::PhantomData<(Q, B)>,
+        )
+        where
+            K: Key,
+            B: RateLimitBackend;
+
+        impl<K, Q, B> AsRef<K::Extractor> for $name<K, Q, B>
+        where
+            K: Key,
+            B: RateLimitBackend,
+        {
+            fn as_ref(&self) -> &K::Extractor {
+                &self.0
+            }
+        }
+
+        impl<K, Q, B> AsMut<K::Extractor> for $name<K, Q, B>
+        where
+            K: Key,
+            B: RateLimitBackend,
+        {
+            fn as_mut(&mut self) -> &mut K::Extractor {
+                &mut self.0
+            }
+        }
+
+        impl<K, Q, B> Deref for $name<K, Q, B>
+        where
+            K: Key,
+            B: RateLimitBackend,
+        {
+            type Target = K::Extractor;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl<K, Q, B> DerefMut for $name<K, Q, B>
+        where
+            K: Key,
+            B: RateLimitBackend,
+        {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+
+        impl<K, Q, B> Display for $name<K, Q, B>
+        where
+            K: Key,
+            B: RateLimitBackend,
+            K::Extractor: Display,
+        {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl<K, Q, B> $name<K, Q, B>
+        where
+            K: Key,
+            B: RateLimitBackend,
+        {
+            /// Returns the quota resolved for this request.
+            pub fn resolved_quota(&self) -> Quota {
+                self.1
+            }
+
+            /// Consumes the limit and returns the inner extractor and resolved quota.
+            pub fn into_parts(self) -> (K::Extractor, Quota) {
+                (self.0, self.1)
+            }
+
+            /// Consumes the limit and returns the inner extractor.
+            pub fn into_inner(self) -> K::Extractor {
+                self.0
+            }
+        }
+
+        impl<K, Q, B, S> FromRequestParts<S> for $name<K, Q, B>
+        where
+            B: RateLimitBackend,
+            B::Error: Display,
+            S: Send + Sync,
+            K: Key + StorageKey,
+            K::Extractor: FromRequestParts<S> + Send,
+            Q: QuotaSource<S>,
+            LimitState<K, $policy, B>: FromRef<S>,
+        {
+            type Rejection = LimitRejection<
+                <<K as Key>::Extractor as FromRequestParts<S>>::Rejection,
+                Q::Rejection,
+            >;
+
+            fn from_request_parts(
+                parts: &mut Parts,
+                state: &S,
+            ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send
+            where
+                S: Sync,
+            {
+                async move {
+                    let key_extractor = match K::Extractor::from_request_parts(parts, state).await {
+                        Ok(ke) => ke,
+                        Err(rejection) => {
+                            return Err(LimitRejection::KeyExtractionFailure(rejection));
+                        }
+                    };
+
+                    let quota = match Q::resolve(parts, state).await {
+                        Ok(quota) => quota,
+                        Err(rejection) => {
+                            return Err(LimitRejection::QuotaResolutionFailure(rejection));
+                        }
+                    };
+
+                    let limit_state: LimitState<K, $policy, B> = FromRef::from_ref(state);
+                    let key = K::from_extractor(&key_extractor);
+                    let snapshot = limit_state
+                        .check(key, quota)
+                        .await
+                        .map_err(|error| LimitRejection::Backend(error.to_string()))?;
+
+                    if snapshot.allowed {
+                        parts.extensions.insert(RateLimitInfo(snapshot));
+                        Ok(Self(
+                            key_extractor,
+                            quota,
+                            std::marker::PhantomData,
+                        ))
+                    } else {
+                        Err(LimitRejection::RateLimitExceeded(snapshot))
+                    }
+                }
+            }
+        }
+    };
+}
+
+define_dynamic_limit_extractor! {
+    /// Token-bucket rate limit extractor with a runtime [`QuotaSource`].
+    DynamicLimit => TokenBucketPolicy
+}
+
+define_dynamic_limit_extractor! {
+    /// Fixed-window rate limit extractor with a runtime [`QuotaSource`].
+    DynamicFixedWindowLimit => FixedWindowPolicy
+}
+
+define_dynamic_limit_extractor! {
+    /// Sliding-window rate limit extractor with a runtime [`QuotaSource`].
+    DynamicSlidingWindowLimit => SlidingWindowPolicy
+}
+
 /// Token-bucket rate limit configured to apply per second.
 pub type LimitPerSecond<const COUNT: usize, K, B = MemoryBackend> = Limit<COUNT, 1000, K, B>;
 
@@ -288,9 +456,12 @@ where
 
 /// Enumerates possible failure modes for rate limiting when extracting from request parts.
 #[derive(Debug)]
-pub enum LimitRejection<R> {
+pub enum LimitRejection<K, Q = Infallible> {
     /// Indicates a failure during key extraction, storing the underlying rejection reason.
-    KeyExtractionFailure(R),
+    KeyExtractionFailure(K),
+
+    /// Indicates that quota resolution failed.
+    QuotaResolutionFailure(Q),
 
     /// Indicates that the rate limit has been exceeded.
     RateLimitExceeded(RateLimitSnapshot),
@@ -299,29 +470,32 @@ pub enum LimitRejection<R> {
     Backend(String),
 }
 
-impl<R: Display> Display for LimitRejection<R> {
+impl<K: Display, Q: Display> Display for LimitRejection<K, Q> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LimitRejection::KeyExtractionFailure(r) => write!(f, "{r}"),
+            LimitRejection::QuotaResolutionFailure(r) => write!(f, "{r}"),
             LimitRejection::RateLimitExceeded(_) => write!(f, "Rate limit exceeded."),
             LimitRejection::Backend(message) => write!(f, "Rate limit storage failure: {message}"),
         }
     }
 }
 
-impl<R: Error + 'static> Error for LimitRejection<R> {
+impl<K: Error + 'static, Q: Error + 'static> Error for LimitRejection<K, Q> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            LimitRejection::KeyExtractionFailure(ve) => Some(ve),
+            LimitRejection::KeyExtractionFailure(error) => Some(error),
+            LimitRejection::QuotaResolutionFailure(error) => Some(error),
             LimitRejection::RateLimitExceeded(_) | LimitRejection::Backend(_) => None,
         }
     }
 }
 
-impl<R: IntoResponse> IntoResponse for LimitRejection<R> {
+impl<K: IntoResponse, Q: IntoResponse> IntoResponse for LimitRejection<K, Q> {
     fn into_response(self) -> Response {
         match self {
             LimitRejection::KeyExtractionFailure(rejection) => rejection.into_response(),
+            LimitRejection::QuotaResolutionFailure(rejection) => rejection.into_response(),
             LimitRejection::RateLimitExceeded(snapshot) => {
                 let now_ms = now_ms();
                 let mut response =
@@ -525,5 +699,81 @@ mod tests {
         assert!(left.check(uri.clone(), quota).await.expect("left").allowed);
         assert!(!left.check(uri.clone(), quota).await.expect("left").allowed);
         assert!(right.check(uri, quota).await.expect("right").allowed);
+    }
+
+    #[derive(Clone)]
+    struct ConfigState {
+        limits: LimitState<Uri>,
+        api_quota: Quota,
+    }
+
+    impl FromRef<ConfigState> for LimitState<Uri> {
+        fn from_ref(state: &ConfigState) -> Self {
+            state.limits.clone()
+        }
+    }
+
+    impl FromRef<ConfigState> for Quota {
+        fn from_ref(state: &ConfigState) -> Quota {
+            state.api_quota
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct ApiQuota(Quota);
+
+    impl FromRef<ConfigState> for ApiQuota {
+        fn from_ref(state: &ConfigState) -> Self {
+            ApiQuota(state.api_quota)
+        }
+    }
+
+    impl From<ApiQuota> for Quota {
+        fn from(value: ApiQuota) -> Self {
+            value.0
+        }
+    }
+
+    #[tokio::test]
+    async fn dynamic_limit_reads_quota_from_state() {
+        const ROUTE: &str = "/dynamic";
+        async fn handler(_: DynamicLimit<Uri, Quota>) -> impl IntoResponse {}
+
+        let state = ConfigState {
+            limits: LimitState::default(),
+            api_quota: Quota::per_second(2),
+        };
+
+        let app = Router::new().route(ROUTE, get(handler)).with_state(state);
+
+        let server = TestServer::new(app);
+
+        assert_eq!(server.get(ROUTE).await.status_code(), StatusCode::OK);
+        assert_eq!(server.get(ROUTE).await.status_code(), StatusCode::OK);
+        assert_eq!(
+            server.get(ROUTE).await.status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+
+    #[tokio::test]
+    async fn dynamic_limit_state_quota_newtype() {
+        const ROUTE: &str = "/dynamic_newtype";
+        async fn handler(_: DynamicLimit<Uri, ApiQuota>) -> impl IntoResponse {}
+
+        let state = ConfigState {
+            limits: LimitState::default(),
+            api_quota: Quota::per_second(1),
+        };
+
+        let app = Router::new().route(ROUTE, get(handler)).with_state(state);
+
+        let server = TestServer::new(app);
+
+        assert_eq!(server.get(ROUTE).await.status_code(), StatusCode::OK);
+        assert_eq!(
+            server.get(ROUTE).await.status_code(),
+            StatusCode::TOO_MANY_REQUESTS
+        );
     }
 }

--- a/src/policy/fixed_window.rs
+++ b/src/policy/fixed_window.rs
@@ -120,4 +120,17 @@ mod tests {
         assert!(window.try_acquire(at(1100)).allowed);
         assert!(!window.try_acquire(at(1200)).allowed);
     }
+
+    #[test]
+    fn round_trips_through_json() {
+        let mut state = window(Quota::new(3, 1000));
+        assert!(state.try_acquire(at(0)).allowed);
+        assert!(state.try_acquire(at(100)).allowed);
+
+        let encoded = state.encode().expect("encode");
+        let mut decoded = FixedWindowState::decode(&encoded, Quota::new(3, 1000)).expect("decode");
+
+        assert!(decoded.try_acquire(at(200)).allowed);
+        assert!(!decoded.try_acquire(at(300)).allowed);
+    }
 }

--- a/src/policy/proptest_policies.rs
+++ b/src/policy/proptest_policies.rs
@@ -129,4 +129,52 @@ proptest! {
 
         prop_assert_eq!(allowed, max);
     }
+
+    #[test]
+    fn fixed_window_never_exceeds_max_within_each_window(
+        max in 1usize..20,
+        per_ms in 200u64..2000,
+        offsets in monotonic_offsets(80, 400),
+    ) {
+        let quota = Quota::new(max, per_ms);
+        let mut state = FixedWindowState::new_at(quota, BASE_MS);
+        let mut allowed_in_window = 0usize;
+        let mut reset_at = 0u64;
+
+        for offset in offsets {
+            let snapshot = state.try_acquire(BASE_MS + offset);
+            if reset_at != snapshot.reset_at_ms {
+                allowed_in_window = 0;
+                reset_at = snapshot.reset_at_ms;
+            }
+            if snapshot.allowed {
+                allowed_in_window += 1;
+            }
+            prop_assert!(allowed_in_window <= max);
+        }
+    }
+
+    #[test]
+    fn sliding_window_never_exceeds_max_within_each_window(
+        max in 1usize..20,
+        per_ms in 200u64..2000,
+        offsets in monotonic_offsets(80, 400),
+    ) {
+        let quota = Quota::new(max, per_ms);
+        let mut state = SlidingWindowState::new_at(quota, BASE_MS);
+        let mut allowed_in_window = 0usize;
+        let mut reset_at = 0u64;
+
+        for offset in offsets {
+            let snapshot = state.try_acquire(BASE_MS + offset);
+            if reset_at != snapshot.reset_at_ms {
+                allowed_in_window = 0;
+                reset_at = snapshot.reset_at_ms;
+            }
+            if snapshot.allowed {
+                allowed_in_window += 1;
+            }
+            prop_assert!(allowed_in_window <= max);
+        }
+    }
 }

--- a/src/policy/sliding_window.rs
+++ b/src/policy/sliding_window.rs
@@ -135,4 +135,18 @@ mod tests {
             assert!(state.try_acquire(at(2000)).allowed);
         }
     }
+
+    #[test]
+    fn round_trips_through_json() {
+        let mut state = window(Quota::new(3, 1000));
+        assert!(state.try_acquire(at(0)).allowed);
+        assert!(state.try_acquire(at(100)).allowed);
+
+        let encoded = state.encode().expect("encode");
+        let mut decoded =
+            SlidingWindowState::decode(&encoded, Quota::new(3, 1000)).expect("decode");
+
+        assert!(decoded.try_acquire(at(200)).allowed);
+        assert!(!decoded.try_acquire(at(300)).allowed);
+    }
 }

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -86,3 +86,31 @@ pub struct QuotaFingerprint {
     /// Optional burst capacity.
     pub burst: Option<usize>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_distinguishes_quotas() {
+        assert_ne!(
+            Quota::new(1, 1000).fingerprint(),
+            Quota::new(2, 1000).fingerprint()
+        );
+        assert_ne!(
+            Quota::new(5, 1000).fingerprint(),
+            Quota::new(5, 2000).fingerprint()
+        );
+        assert_ne!(
+            Quota::with_burst(5, 1000, 10).fingerprint(),
+            Quota::new(5, 1000).fingerprint()
+        );
+    }
+
+    #[test]
+    fn per_second_sets_one_second_period() {
+        let quota = Quota::per_second(10);
+        assert_eq!(quota.max, 10);
+        assert_eq!(quota.per_ms, 1000);
+    }
+}

--- a/src/quota_source.rs
+++ b/src/quota_source.rs
@@ -1,0 +1,45 @@
+use crate::quota::Quota;
+use axum_core::extract::FromRef;
+use axum_core::response::IntoResponse;
+use http::request::Parts;
+use std::convert::Infallible;
+
+/// Resolves a [`Quota`] at request time.
+///
+/// Types that implement [`FromRef`] and [`Into<Quota>`] receive a blanket implementation.
+pub trait QuotaSource<S>: Send + Sync + Sized + 'static {
+    /// Error returned when quota resolution fails.
+    type Rejection: IntoResponse;
+
+    /// Resolves the quota for the current request.
+    fn resolve(
+        parts: &Parts,
+        state: &S,
+    ) -> impl std::future::Future<Output = Result<Quota, Self::Rejection>> + Send;
+}
+
+impl<S, Q> QuotaSource<S> for Q
+where
+    Q: FromRef<S> + Into<Quota> + Send + Sync + 'static,
+    S: Sync,
+{
+    type Rejection = Infallible;
+
+    fn resolve(
+        _parts: &Parts,
+        state: &S,
+    ) -> impl std::future::Future<Output = Result<Quota, Self::Rejection>> + Send {
+        let quota = Q::from_ref(state).into();
+        async move { Ok(quota) }
+    }
+}
+
+/// Resolves a fixed [`Quota`] stored in application state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FixedQuota(pub Quota);
+
+impl From<FixedQuota> for Quota {
+    fn from(value: FixedQuota) -> Self {
+        value.0
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

支持运行时动态额度：策略（算法）仍在 handler 类型中固定，额度通过 [`QuotaSource`] 从应用状态或配置解析。

## 新增 API

| 类型 | 说明 |
|------|------|
| `QuotaSource<S>` | 请求时解析 `Quota` 的 trait |
| `DynamicLimit<K, Q>` | 令牌桶 + 动态额度 |
| `DynamicFixedWindowLimit<K, Q>` | 固定窗口 + 动态额度 |
| `DynamicSlidingWindowLimit<K, Q>` | 滑动窗口 + 动态额度 |
| `FixedQuota` | 状态中存放固定额度的辅助类型 |

### 常见用法（额度从配置加载）

```rust
impl FromRef<AppState> for Quota {
    fn from_ref(state: &AppState) -> Quota { state.api_quota }
}

async fn handler(_: DynamicLimit<Uri, Quota>) { }
```

多额度场景使用 newtype + `FromRef`（`ApiQuota` 等），自动获得 blanket `QuotaSource` 实现。

## 其他变更

- `LimitRejection` 增加 `QuotaResolutionFailure` 变体（第二类型参数，默认 `Infallible`，静态 extractor 无破坏）
- 静态 `Limit<COUNT, PER, K>` 保持不变

## 注意

修改额度会改变 `quota.fingerprint()`，存储计数器不会继承（已在 README 说明）。

## 测试

- [x] `cargo test --all-features`（25 单元测试 + 5 doctest）
- [x] `cargo clippy --all-features -- -D warnings`

版本：**0.1.0**（首个正式版本）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f162e-467c-7095-a61d-46e6824edb41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f162e-467c-7095-a61d-46e6824edb41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

